### PR TITLE
Bump C# language version

### DIFF
--- a/BunqSdk.Samples/BunqSdk.Samples.csproj
+++ b/BunqSdk.Samples/BunqSdk.Samples.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Bunq.Sdk.Samples</RootNamespace>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <LangVersion>5</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BunqSdk\BunqSdk.csproj" />

--- a/BunqSdk.Tests/BunqSdk.Tests.csproj
+++ b/BunqSdk.Tests/BunqSdk.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <RootNamespace>Bunq.Sdk.Tests</RootNamespace>
-    <LangVersion>5</LangVersion>
+    <LangVersion>default</LangVersion>
     <AssemblyName>BunqSdk.Tests.xunit.runner.json</AssemblyName>
   </PropertyGroup>
   <ItemGroup>

--- a/BunqSdk/BunqSdk.csproj
+++ b/BunqSdk/BunqSdk.csproj
@@ -3,7 +3,7 @@
     <RuntimeFrameworkVersion>1.1.2</RuntimeFrameworkVersion>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <OutputType>Library</OutputType>
-    <LangVersion>5</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Bunq.Sdk</AssemblyName>


### PR DESCRIPTION
 - allows to use a more recent version of C#
 - .net core ships with C# 6 starting v1.0, so why not using a more modern version right away?