### PR TITLE
Feature/is session active#33

### DIFF
--- a/BunqSdk/Context/ApiContext.cs
+++ b/BunqSdk/Context/ApiContext.cs
@@ -176,8 +176,19 @@ namespace Bunq.Sdk.Context
         /// </summary>
         public void EnsureSessionActive()
         {
-            if (SessionContext == null) return;
+            if (!IsSessionActive())
+            {
+                ResetSession();
+            }
+        }
 
+        public bool IsSessionActive()
+        {
+            if (SessionContext == null)
+            {
+                return false;
+            }
+            
             var timeToExpiry = SessionContext.ExpiryTime.Subtract(DateTime.Now);
             var timeToExpiryMinimum = new TimeSpan(
                 TIME_UNIT_COUNT_NONE,
@@ -185,10 +196,7 @@ namespace Bunq.Sdk.Context
                 TIME_TO_SESSION_EXPIRY_MINIMUM_SECONDS
             );
 
-            if (timeToExpiry < timeToExpiryMinimum)
-            {
-                ResetSession();
-            }
+            return timeToExpiry > timeToExpiryMinimum;
         }
 
         /// <summary>

--- a/BunqSdk/Http/ApiClient.cs
+++ b/BunqSdk/Http/ApiClient.cs
@@ -18,7 +18,7 @@ namespace Bunq.Sdk.Http
     {
 
         /// <summary>
-        ///  Endpoints not requiring active session for the request to succeed.
+        /// Endpoints not requiring active session for the request to succeed.
         /// </summary>
         private const string DEVICE_SERVER_URL = "device-server";
         private const string INSTALLATION_URL = "installation";

--- a/BunqSdk/Http/ApiClient.cs
+++ b/BunqSdk/Http/ApiClient.cs
@@ -17,10 +17,12 @@ namespace Bunq.Sdk.Http
     public class ApiClient
     {
 
+        /// <summary>
+        ///  Endpoints not requiring active session for the request to succeed.
+        /// </summary>
         private const string DEVICE_SERVER_URL = "device-server";
         private const string INSTALLATION_URL = "installation";
         private const string SESSION_SERVER_URL = "session-server";
-
         private static readonly string[] URIS_NOT_REQUIRING_ACTIVE_SESSION = new string[]
         {
             DEVICE_SERVER_URL,

--- a/BunqSdk/Http/ApiClient.cs
+++ b/BunqSdk/Http/ApiClient.cs
@@ -16,6 +16,18 @@ namespace Bunq.Sdk.Http
 {
     public class ApiClient
     {
+
+        private const string DEVICE_SERVER_URL = "device-server";
+        private const string INSTALLATION_URL = "installation";
+        private const string SESSION_SERVER_URL = "session-server";
+
+        private static readonly string[] URIS_NOT_REQUIRING_ACTIVE_SESSION = new string[]
+        {
+            DEVICE_SERVER_URL,
+            INSTALLATION_URL,
+            SESSION_SERVER_URL
+        };
+
         /// <summary>
         /// Header constants.
         /// </summary>
@@ -115,7 +127,7 @@ namespace Bunq.Sdk.Http
         {
             var requestMessage = CreateHttpRequestMessage(method, uriRelative, uriParams, requestBodyBytes);
 
-            return SendRequest(requestMessage, customHeaders);
+            return SendRequest(requestMessage, customHeaders, uriRelative);
         }
 
         private BunqResponseRaw SendRequest(HttpMethod method, string uriRelative,
@@ -123,13 +135,17 @@ namespace Bunq.Sdk.Http
         {
             var requestMessage = CreateHttpRequestMessage(method, uriRelative, uriParams);
 
-            return SendRequest(requestMessage, customHeaders);
+            return SendRequest(requestMessage, customHeaders, uriRelative);
         }
 
         private BunqResponseRaw SendRequest(HttpRequestMessage requestMessage,
-            IDictionary<string, string> customHeaders)
+            IDictionary<string, string> customHeaders, string uriRelative)
         {
-            apiContext.EnsureSessionActive();
+            if (!URIS_NOT_REQUIRING_ACTIVE_SESSION.Contains(uriRelative))
+            {
+                apiContext.EnsureSessionActive();
+            }
+            
             SetDefaultHeaders(requestMessage);
             SetHeaders(requestMessage, customHeaders);
             SetSessionHeaders(requestMessage);


### PR DESCRIPTION
## Context 
#33 

## What has been done
This pr introduces a new way to handle `SessionContext`. Now it is possible to do the following:

```
if (!apiContext.IsSessionActive()) {
    apiContext.ResetSession();
    apiContext.Save();
}
```

This way there is no saving an unchanged context.

Closes #33 