### PR TITLE
Add name parameter to Pointer constructor

### DIFF
--- a/BunqSdk/Model/Generated/Object/Pointer.cs
+++ b/BunqSdk/Model/Generated/Object/Pointer.cs
@@ -26,10 +26,11 @@ namespace Bunq.Sdk.Model.Generated.Object
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
     
-        public Pointer(string type, string value)
+        public Pointer(string type, string value, string name)
         {
             Type = type;
             Value = value;
+            Name = name;
         }
     }
 }


### PR DESCRIPTION
The API sample to create a payment doesn't work when a pointer doesn't have a name.
```
Bunq.Sdk.Exception.BadRequestException has been thrown
Pointer has no name set
```