### PR TITLE
Bunq.Sdk support for .netstandard15

### DIFF
--- a/BunqSdk/BunqSdk.csproj
+++ b/BunqSdk/BunqSdk.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RuntimeFrameworkVersion>1.1.2</RuntimeFrameworkVersion>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-    <OutputType>Library</OutputType>
+    <TargetFramework>netstandard1.5</TargetFramework>
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -26,6 +24,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3-*" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="../CHANGELOG.md" />

--- a/BunqSdk/Json/AnchorObjectConverter.cs
+++ b/BunqSdk/Json/AnchorObjectConverter.cs
@@ -34,13 +34,13 @@ namespace Bunq.Sdk.Json
 
             if (!model.IsAllFieldNull()) return model;
             
-            var fields = objectType.GetProperties();
+            var fields = objectType.GetTypeInfo().GetProperties();
 
             foreach (var field in fields)
             {
                 var fieldType = field.PropertyType;
                     
-                if (!typeof(BunqModel).IsAssignableFrom(fieldType))
+                if (!typeof(BunqModel).GetTypeInfo().IsAssignableFrom(fieldType))
                 {
                     continue;
                 }
@@ -55,7 +55,7 @@ namespace Bunq.Sdk.Json
 
         public override bool CanConvert(Type objectType)
         {
-            return typeof(IAnchorObjectInterface).IsAssignableFrom(objectType);
+            return typeof(IAnchorObjectInterface).GetTypeInfo().IsAssignableFrom(objectType);
         }
     }
 }

--- a/BunqSdk/Json/BunqContractResolver.cs
+++ b/BunqSdk/Json/BunqContractResolver.cs
@@ -64,7 +64,7 @@ namespace Bunq.Sdk.Json
 
         private JsonConverter GetCustomConverterOrNull(Type objectType)
         {
-            if (typeof(IAnchorObjectInterface).IsAssignableFrom(objectType))
+            if (typeof(IAnchorObjectInterface).GetTypeInfo().IsAssignableFrom(objectType))
             {
                 return converterRegistry.ContainsKey(typeof(IAnchorObjectInterface))
                     ? converterRegistry[typeof(IAnchorObjectInterface)]


### PR DESCRIPTION
Related issue: #26

By creating a .netstandard library, this library can be used on a lot more platforms.