### PR TITLE
Typo fix from java to c#

### DIFF
--- a/BunqSdk.Tests/README.md
+++ b/BunqSdk.Tests/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 Hi developers!
 
-Welcome to the bunq Java SDK integration tests. Currently we are not
+Welcome to the bunq C# SDK integration tests. Currently we are not
 targeting the 100% test coverage, but rather want to be certain that the most
 common scenarios can run without any errors.
 


### PR DESCRIPTION
## This PR fixes the following issues:

There was a typo in the README.MD file under the tests project refering to the java-SDK.
 ` -Welcome to the bunq Java SDK integration tests. Currently we are not`
Changed it to match the project:
`-Welcome to the bunq C# SDK integration tests. Currently we are not`

- [x] Tested