### PR TITLE
Add ability to save context to streams

### DIFF
--- a/BunqSdk.Tests/Context/ApiContextTest.cs
+++ b/BunqSdk.Tests/Context/ApiContextTest.cs
@@ -1,4 +1,5 @@
-﻿using Bunq.Sdk.Context;
+﻿using System.IO;
+using Bunq.Sdk.Context;
 using Xunit;
 
 namespace Bunq.Sdk.Tests.Context
@@ -42,6 +43,23 @@ namespace Bunq.Sdk.Tests.Context
             var apiContextJson = apiContext.ToJson();
             apiContext.Save(CONTEXT_FILENAME_TEST);
             var apiContextRestored = ApiContext.Restore(CONTEXT_FILENAME_TEST);
+
+            Assert.Equal(apiContextJson, apiContextRestored.ToJson());
+        }
+
+        /// <summary>
+        /// Tests saving and restoring of the API context.
+        /// </summary>
+        [Fact]
+        public void TestApiContextSaveRestoreReader()
+        {
+            var buffer = new MemoryStream();
+            var apiContextJson = apiContext.ToJson();
+
+            apiContext.Save(buffer);
+
+            buffer.Seek(0, SeekOrigin.Begin);
+            var apiContextRestored = ApiContext.Restore(buffer);
 
             Assert.Equal(apiContextJson, apiContextRestored.ToJson());
         }

--- a/BunqSdk/Context/ApiContext.cs
+++ b/BunqSdk/Context/ApiContext.cs
@@ -188,7 +188,7 @@ namespace Bunq.Sdk.Context
             {
                 return false;
             }
-            
+
             var timeToExpiry = SessionContext.ExpiryTime.Subtract(DateTime.Now);
             var timeToExpiryMinimum = new TimeSpan(
                 TIME_UNIT_COUNT_NONE,
@@ -223,6 +223,22 @@ namespace Bunq.Sdk.Context
         }
 
         /// <summary>
+        /// Save a JSON representation of the API Context to a given writer.
+        /// </summary>
+        public void Save(Stream stream)
+        {
+            try
+            {
+                var writer = new StreamWriter(stream, ENCODING_BUNQ_CONF);
+                writer.Write(ToJson());
+            }
+            catch (IOException exception)
+            {
+                throw new BunqException(ERROR_COULD_NOT_SAVE_API_CONTEXT, exception);
+            }
+        }
+
+        /// <summary>
         /// Serialize the API Context to JSON.
         /// </summary>
         public string ToJson()
@@ -246,6 +262,22 @@ namespace Bunq.Sdk.Context
             try
             {
                 return FromJson(File.ReadAllText(fileName, ENCODING_BUNQ_CONF));
+            }
+            catch (IOException exception)
+            {
+                throw new BunqException(ERROR_COULD_NOT_RESTORE_API_CONTEXT, exception);
+            }
+        }
+
+        /// <summary>
+        /// Restores a context from a given reader.
+        /// </summary>
+        public static ApiContext Restore(Stream stream)
+        {
+            try
+            {
+                var reader = new StreamReader(stream);
+                return FromJson(reader.ReadToEnd());
             }
             catch (IOException exception)
             {


### PR DESCRIPTION
This adds the ability to save an api context to a stream, rather than a file. This makes the save more flexible and removes the dependency to the file system for saving and loading contexts.

The pull requests comes with extra unit tests ✅ 