### PR TITLE
bunq/sdk_csharp#92 Fix key generation on .NET Framework

### DIFF
--- a/BunqSdk/Security/SecurityUtils.cs
+++ b/BunqSdk/Security/SecurityUtils.cs
@@ -230,9 +230,12 @@ namespace Bunq.Sdk.Security
         /// </summary>
         public static RSA GenerateKeyPair()
         {
+#if NETSTANDARD2_0 || NET46 || NET45 || NET451 || NET452 || NET40 || NET35
+            var rsa = (RSA)new RSACryptoServiceProvider(RSA_KEY_SIZE);
+#else
             var rsa = RSA.Create();
             rsa.KeySize = RSA_KEY_SIZE;
-
+#endif
             return rsa;
         }
 


### PR DESCRIPTION

## This PR closes/fixes the following issues:
 - Closes bunq/sdk_csharp#92
    - [ ] Tested in on .NET Framework 4.6.2