### PR TITLE
Fix key generation on .NET Framework. (bunq/sdk_csharp#92)

### DIFF
--- a/BunqSdk/Security/SecurityUtils.cs
+++ b/BunqSdk/Security/SecurityUtils.cs
@@ -230,9 +230,12 @@ namespace Bunq.Sdk.Security
         /// </summary>
         public static RSA GenerateKeyPair()
         {
+#if NETSTANDARD2_0 || NET46 || NET45 || NET451 || NET452 || NET40 || NET35
+            var rsa = (RSA)new RSACryptoServiceProvider(RSA_KEY_SIZE);
+#else
             var rsa = RSA.Create();
             rsa.KeySize = RSA_KEY_SIZE;
-
+#endif
             return rsa;
         }
 


### PR DESCRIPTION

 - Closes bunq/sdk_csharp#92
    - [x] Tested on .NET Framework 4.6 manually
